### PR TITLE
Fix for torch.cat failing in sparse_collate function when  coordinate tensor is on gpu

### DIFF
--- a/torchsparse/utils/helpers.py
+++ b/torchsparse/utils/helpers.py
@@ -151,12 +151,12 @@ def sparse_collate(coords,
 
         if not coord_float:
             coords_batch.append(
-                torch.cat((coord, torch.ones(num_points, 1).int() * batch_id),
+                torch.cat((coord, torch.ones(num_points, 1, coord.device).int() * batch_id),
                           1))
         else:
             coords_batch.append(
                 torch.cat(
-                    (coord, torch.ones(num_points, 1).float() * batch_id), 1))
+                    (coord, torch.ones(num_points, 1, coord.device).float() * batch_id), 1))
 
         # Features
         feats_batch.append(feat)

--- a/torchsparse/utils/helpers.py
+++ b/torchsparse/utils/helpers.py
@@ -151,12 +151,12 @@ def sparse_collate(coords,
 
         if not coord_float:
             coords_batch.append(
-                torch.cat((coord, torch.ones(num_points, 1, coord.device).int() * batch_id),
+                torch.cat((coord, torch.ones((num_points, 1), device=coord.device).int() * batch_id),
                           1))
         else:
             coords_batch.append(
                 torch.cat(
-                    (coord, torch.ones(num_points, 1, coord.device).float() * batch_id), 1))
+                    (coord, torch.ones((num_points, 1), device=coord.device).float() * batch_id), 1))
 
         # Features
         feats_batch.append(feat)


### PR DESCRIPTION
Fix for torch.cat failing in sparse_collate function when the coords parameter happens to be on the gpu. The failure is caused due to the two parts being concatenated not being on the same device. By default, torch.ones creates the tensor on the cpu. So, if the coord happens to be on gpu, the error occurs. Fixed by creating the torch.ones tensor on the same device as the coord.