### PR TITLE
Update to reduce the chances of bucket overflow error in 

### DIFF
--- a/torchsparse/src/others/query.cpp
+++ b/torchsparse/src/others/query.cpp
@@ -15,7 +15,11 @@ std::vector<at::Tensor> query_forward(
   //return group_point_forward_gpu(points, indices);
   int n = hash_target.size(0);
   int n1 = hash_query.size(0);
-  int table_size =  2 * pow(2,ceil(log2((double)n)));
+  const int nextPow2 = pow(2,ceil(log2((double)n)));
+  // When n is large, the hash values tend to be more evenly distrubuted and choosing table_size to be 
+  // 2 * nextPow2 typically suffices. For smaller n, the effect of uneven distribution of hash values is more
+  // pronounced and hence we choose table_size to be 4 * nextPow2 to reduce the chance of bucket overflow.
+  int table_size =  (n < 2048) ? 4 * nextPow2 : 2 * nextPow2;
   if(table_size < 512){
       table_size = 512;
   }

--- a/torchsparse/utils/helpers.py
+++ b/torchsparse/utils/helpers.py
@@ -152,7 +152,7 @@ def sparse_collate(coords,
         if not coord_float:
             coords_batch.append(
                 torch.cat((coord, torch.ones((num_points, 1), device=coord.device).int() * batch_id),
-                    1))
+                          1))
         else:
             coords_batch.append(
                 torch.cat(

--- a/torchsparse/utils/helpers.py
+++ b/torchsparse/utils/helpers.py
@@ -152,7 +152,7 @@ def sparse_collate(coords,
         if not coord_float:
             coords_batch.append(
                 torch.cat((coord, torch.ones((num_points, 1), device=coord.device).int() * batch_id),
-                          1))
+                    1))
         else:
             coords_batch.append(
                 torch.cat(


### PR DESCRIPTION
 Updated the code computing the value of hash table size, to reduce the chances of bucket overflow error happening in hashmap.cu. When n is small, the effect of uneven distribution of hash values is more pronounced, and we select the table size to be 4 * nextPow2. For larger n, we take it to be 2 * nextPow2. This way, for larger n, when memory size consideration is more important, the table_size gets computed to be same as it used to be. 