### PR TITLE
Replace atomicadd with pytorch impl

### DIFF
--- a/torchsparse/src/common/gpu.cuh
+++ b/torchsparse/src/common/gpu.cuh
@@ -104,11 +104,6 @@ template <typename Dtype1, typename Dtype2>
 void print(const thrust::device_vector<Dtype1> &v1,
            const thrust::device_vector<Dtype2> &v2);
 
-// atomicadd for half types (from aten/src/THC/THCAtomics.cuh)
-static inline  __device__ at::Half atomicAdd(at::Half *address, at::Half val) {
-  return atomicAdd(reinterpret_cast<__half*>(address), val);
-}
-
 // AtomicAddition for double with cuda arch <= 600
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
 #else

--- a/torchsparse/src/interpolation/devox_gpu.cu
+++ b/torchsparse/src/interpolation/devox_gpu.cu
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <thrust/device_vector.h>
 #include <torch/extension.h>
-#include "../common/gpu.cuh"
+#include <THC/THCAtomics.cuh>
 
 
 //input features (n, c), indices (N, 8), weight (N, 8) -> output features (N, c)

--- a/torchsparse/src/others/insertion_gpu.cu
+++ b/torchsparse/src/others/insertion_gpu.cu
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <cmath>
 #include <torch/torch.h>
-#include "../common/gpu.cuh"
+#include <THC/THCAtomics.cuh>
 
 //hashing
 //input N*F float tensor, pointer to output N'*F int64 tensor, N*1 count tensor, N*1 index tensor


### PR DESCRIPTION
Replace the cuda atomicadd op with the pytorch one, which supports `at::Half` and other device architectures.

Tested on cuda devices with compute 7.5 and 5.2

Fix #72 #73 #74 