### PR TITLE
Remove unused variable causing warnings

### DIFF
--- a/torchsparse/src/hashmap/hashmap_cpu.cpp
+++ b/torchsparse/src/hashmap/hashmap_cpu.cpp
@@ -26,7 +26,7 @@ HashTableCPU::lookup_vals(const int64_t * const keys, int64_t * const results, c
 
 
 
-int
+void
 HashTableCPU::insert_vals(const int64_t * const keys, const int64_t * const vals, const int n) {
     for(int i = 0; i < 10; i++){
         printf("%d, %d, %d, %d\n", i, i<n, n, i<10);

--- a/torchsparse/src/hashmap/hashmap_cpu_header.hpp
+++ b/torchsparse/src/hashmap/hashmap_cpu_header.hpp
@@ -21,7 +21,7 @@ public:
         //hashmap.set_empty_key(0);
     }
     ~HashTableCPU(){}
-    int insert_vals(const int64_t * const keys, const int64_t * const vals, const int n);
+    void insert_vals(const int64_t * const keys, const int64_t * const vals, const int n);
     void lookup_vals(const int64_t * const keys, int64_t * const results, const int n);
 
 };

--- a/torchsparse/src/interpolation/devox_cpu.cpp
+++ b/torchsparse/src/interpolation/devox_cpu.cpp
@@ -9,7 +9,7 @@ at::Tensor cpu_devoxelize_forward(
     const at::Tensor indices,
     const at::Tensor weight)
 {
-  int b = feat.size(0);
+  //int b = feat.size(0);
   //printf("%d\n", b);
   int c = feat.size(1);
   int N = indices.size(0);

--- a/torchsparse/src/interpolation/devox_deterministic.cpp
+++ b/torchsparse/src/interpolation/devox_deterministic.cpp
@@ -9,7 +9,7 @@ at::Tensor deterministic_devoxelize_forward(
     const at::Tensor indices,
     const at::Tensor weight)
 {
-  int b = feat.size(0);
+  //int b = feat.size(0);
   //printf("%d\n", b);
   int c = feat.size(1);
   int N = indices.size(0);

--- a/torchsparse/src/others/insertion_cpu.cpp
+++ b/torchsparse/src/others/insertion_cpu.cpp
@@ -36,7 +36,7 @@ at::Tensor cpu_insertion_backward(
   //return group_point_forward_gpu(points, indices);
 
   int c = top_grad.size(1);
-  int N1 = counts.size(0);
+  //int N1 = counts.size(0);
   at::Tensor bottom_grad = torch::zeros({N, c}, at::device(idx.device()).dtype(at::ScalarType::Float));
   for (int i = 0; i < N; i++)
   {


### PR DESCRIPTION
Removed a few unused variable. Build no longer shows any warning.