### PR TITLE
support Tensor input to make_tuple

### DIFF
--- a/torchsparse/utils/helpers.py
+++ b/torchsparse/utils/helpers.py
@@ -256,3 +256,10 @@ def make_tuple(inputs, dimension=3):
     elif isinstance(inputs, tuple):
         assert len(inputs) == dimension, 'Input length and dimension mismatch'
         return inputs
+    elif isinstance(inputs, torch.Tensor):
+        inputs = inputs.squeeze()
+        shape = inputs.shape
+        assert len(shape) == 1 and shape[0] == dimension, 'Input length and dimension mismatch'
+        if inputs.is_cuda:
+            inputs = inputs.cpu()
+        return tuple((t.item() for t in inputs))


### PR DESCRIPTION
According to the type annotation, `tensor_stride` can be a Tensor: https://github.com/mit-han-lab/torchsparse/blob/master/torchsparse/utils/kernel.py#L21

But `make_tuple` fails silently (returns None) with Tensor input. This adds an elif branch for make_tuple from Tensor.

Not extensively tested -- it is possible that some other code will break if it relies on the None output here.