### PR TITLE
Add support for Mac OS

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -44,6 +44,7 @@ class RandomDataset:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
+    parser.add_argument('--device', type=str, default='cuda')
     parser.add_argument('--amp_enabled', action='store_true')
     args = parser.parse_args()
 
@@ -72,15 +73,15 @@ if __name__ == '__main__':
         spnn.BatchNorm(32),
         spnn.ReLU(True),
         spnn.Conv3d(32, 10, 1),
-    ).cuda()
+    ).to(args.device)
 
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     scaler = amp.GradScaler(enabled=args.amp_enabled)
 
     for k, feed_dict in enumerate(dataflow):
-        inputs = feed_dict['input'].cuda()
-        labels = feed_dict['label'].cuda()
+        inputs = feed_dict['input'].to(device=args.device)
+        labels = feed_dict['label'].to(device=args.device)
 
         with amp.autocast(enabled=args.amp_enabled):
             outputs = model(inputs)

--- a/torchsparse/backend/convolution/convolution_cpu.h
+++ b/torchsparse/backend/convolution/convolution_cpu.h
@@ -1,5 +1,4 @@
-#ifndef TORCHSPARSE_CONVOLUTION_CPU
-#define TORCHSPARSE_CONVOLUTION_CPU
+#pragma once
 
 #include <torch/torch.h>
 
@@ -11,5 +10,3 @@ void convolution_backward_cpu(at::Tensor in_feat, at::Tensor grad_in_feat,
                               at::Tensor grad_out_feat, at::Tensor kernel,
                               at::Tensor grad_kernel, at::Tensor neighbor_map,
                               at::Tensor neighbor_offset, const bool transpose);
-
-#endif

--- a/torchsparse/backend/convolution/convolution_cuda.h
+++ b/torchsparse/backend/convolution/convolution_cuda.h
@@ -1,5 +1,4 @@
-#ifndef TORCHSPARSE_CONVOLUTION_CUDA
-#define TORCHSPARSE_CONVOLUTION_CUDA
+#pragma once
 
 #include <torch/torch.h>
 
@@ -12,5 +11,3 @@ void convolution_backward_cuda(at::Tensor in_feat, at::Tensor grad_in_feat,
                                at::Tensor grad_kernel, at::Tensor neighbor_map,
                                at::Tensor neighbor_offset,
                                const bool transpose);
-
-#endif

--- a/torchsparse/backend/devoxelize/devoxelize_cpu.h
+++ b/torchsparse/backend/devoxelize/devoxelize_cpu.h
@@ -1,5 +1,4 @@
-#ifndef TORCHSPARSE_DEVOXELIZE_CPU
-#define TORCHSPARSE_DEVOXELIZE_CPU
+#pragma once
 
 #include <torch/torch.h>
 
@@ -10,5 +9,3 @@ at::Tensor devoxelize_forward_cpu(const at::Tensor feat,
 at::Tensor devoxelize_backward_cpu(const at::Tensor top_grad,
                                    const at::Tensor indices,
                                    const at::Tensor weight, int n);
-
-#endif

--- a/torchsparse/backend/devoxelize/devoxelize_cuda.h
+++ b/torchsparse/backend/devoxelize/devoxelize_cuda.h
@@ -1,5 +1,4 @@
-#ifndef TORCHSPARSE_DEVOXELIZE_CUDA
-#define TORCHSPARSE_DEVOXELIZE_CUDA
+#pragma once
 
 #include <torch/torch.h>
 
@@ -10,5 +9,3 @@ at::Tensor devoxelize_forward_cuda(const at::Tensor feat,
 at::Tensor devoxelize_backward_cuda(const at::Tensor top_grad,
                                     const at::Tensor indices,
                                     const at::Tensor weight, int n);
-
-#endif

--- a/torchsparse/backend/hash/hash_cpu.cpp
+++ b/torchsparse/backend/hash/hash_cpu.cpp
@@ -4,10 +4,10 @@
 
 #include <vector>
 
-void cpu_hash_wrapper(int N, const int *data, long *out) {
+void cpu_hash_wrapper(int N, const int *data, int64_t *out) {
 #pragma omp parallel for
   for (int i = 0; i < N; i++) {
-    unsigned long long hash = 14695981039346656037UL;
+    uint64_t hash = 14695981039346656037UL;
     for (int j = 0; j < 4; j++) {
       hash ^= (unsigned int)data[4 * i + j];
       hash *= 1099511628211UL;
@@ -18,7 +18,7 @@ void cpu_hash_wrapper(int N, const int *data, long *out) {
 }
 
 void cpu_kernel_hash_wrapper(int N, int K, const int *data,
-                             const int *kernel_offset, long int *out) {
+                             const int *kernel_offset, int64_t *out) {
   for (int k = 0; k < K; k++) {
 #pragma omp parallel for
     for (int i = 0; i < N; i++) {
@@ -27,7 +27,7 @@ void cpu_kernel_hash_wrapper(int N, int K, const int *data,
         cur_coord[j] = data[i * 4 + j] + kernel_offset[k * 3 + j];
       }
       cur_coord[3] = data[3];
-      unsigned long long hash = 14695981039346656037UL;
+      uint64_t hash = 14695981039346656037UL;
       for (int j = 0; j < 4; j++) {
         hash ^= (unsigned int)cur_coord[j];
         hash *= 1099511628211UL;
@@ -42,7 +42,7 @@ at::Tensor hash_cpu(const at::Tensor idx) {
   int N = idx.size(0);
   at::Tensor out =
       torch::zeros({N}, at::device(idx.device()).dtype(at::ScalarType::Long));
-  cpu_hash_wrapper(N, idx.data_ptr<int>(), out.data_ptr<long>());
+  cpu_hash_wrapper(N, idx.data_ptr<int>(), out.data_ptr<int64_t>());
   return out;
 }
 
@@ -53,6 +53,7 @@ at::Tensor kernel_hash_cpu(const at::Tensor idx,
   at::Tensor out = torch::zeros(
       {K, N}, at::device(idx.device()).dtype(at::ScalarType::Long));
   cpu_kernel_hash_wrapper(N, K, idx.data_ptr<int>(),
-                          kernel_offset.data_ptr<int>(), out.data_ptr<long>());
+                          kernel_offset.data_ptr<int>(),
+                          out.data_ptr<int64_t>());
   return out;
 }

--- a/torchsparse/backend/hash/hash_cpu.h
+++ b/torchsparse/backend/hash/hash_cpu.h
@@ -1,5 +1,4 @@
-#ifndef _SPARSE_HASH_CPU
-#define _SPARSE_HASH_CPU
+#pragma once
 
 #include <torch/torch.h>
 
@@ -7,5 +6,3 @@ at::Tensor hash_cpu(const at::Tensor idx);
 
 at::Tensor kernel_hash_cpu(const at::Tensor idx,
                            const at::Tensor kernel_offset);
-
-#endif

--- a/torchsparse/backend/hash/hash_cuda.h
+++ b/torchsparse/backend/hash/hash_cuda.h
@@ -1,5 +1,4 @@
-#ifndef TORCHSPARSE_HASH_CUDA
-#define TORCHSPARSE_HASH_CUDA
+#pragma once
 
 #include <torch/torch.h>
 
@@ -7,5 +6,3 @@ at::Tensor hash_cuda(const at::Tensor idx);
 
 at::Tensor kernel_hash_cuda(const at::Tensor idx,
                             const at::Tensor kernel_offset);
-
-#endif

--- a/torchsparse/backend/hashmap/hashmap_cpu.hpp
+++ b/torchsparse/backend/hashmap/hashmap_cpu.hpp
@@ -1,5 +1,4 @@
-#ifndef _CUCKOO_MULTI_CPU_HPP_
-#define _CUCKOO_MULTI_CPU_HPP_
+#pragma once
 
 #include <cmath>
 #include <cstdint>
@@ -23,5 +22,3 @@ class HashTableCPU {
   void lookup_vals(const int64_t* const keys, int64_t* const results,
                    const int n);
 };
-
-#endif

--- a/torchsparse/backend/hashmap/hashmap_cuda.cu
+++ b/torchsparse/backend/hashmap/hashmap_cuda.cu
@@ -4,14 +4,10 @@
 
 #include "hashmap_cuda.cuh"
 
-typedef unsigned long long int VTYPE;
-
-__global__ void cuckooBucketKernel_Multi(VTYPE *const key_buf,
-                                         VTYPE *const val_buf, const int size,
-                                         const VTYPE *const keys,
-                                         const VTYPE *const vals, const int n,
-                                         int *const counters,
-                                         const int num_buckets) {
+__global__ void cuckooBucketKernel_Multi(
+    uint64_t *const key_buf, uint64_t *const val_buf, const int size,
+    const uint64_t *const keys, const uint64_t *const vals, const int n,
+    int *const counters, const int num_buckets) {
   // Get thread index.
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -19,8 +15,8 @@ __global__ void cuckooBucketKernel_Multi(VTYPE *const key_buf,
   if (idx < n) {
     // Do 1st-level hashing to get bucket id, then do atomic add to get index
     // inside the bucket.
-    VTYPE key = keys[idx];
-    VTYPE val = vals[idx];
+    uint64_t key = keys[idx];
+    uint64_t val = vals[idx];
 
     int bucket_num = do_1st_hash(key, num_buckets);
     int bucket_ofs = atomicAdd(&counters[bucket_num], 1);
@@ -37,14 +33,14 @@ __global__ void cuckooBucketKernel_Multi(VTYPE *const key_buf,
 }
 
 __global__ void cuckooInsertKernel_Multi(
-    VTYPE *const key, VTYPE *const val, const VTYPE *const key_buf,
-    const VTYPE *const val_buf, const int size,
+    uint64_t *const key, uint64_t *const val, const uint64_t *const key_buf,
+    const uint64_t *const val_buf, const int size,
     const FuncConfig *const hash_func_configs, const int num_funcs,
     const int *const counters, const int num_buckets, const int evict_bound,
     const int pos_width, int *const rehash_requests) {
   // Create local cuckoo table in shared memory. Size passed in as the third
   // kernel parameter.
-  extern __shared__ VTYPE local_key[];
+  extern __shared__ uint64_t local_key[];
   for (int i = 0; i < num_funcs; ++i) {
     local_key[i * BUCKET_SIZE + threadIdx.x] = EMPTY_CELL;
   }
@@ -54,12 +50,12 @@ __global__ void cuckooInsertKernel_Multi(
 
   // Get thread index.
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  VTYPE cur_idx = idx;
+  uint64_t cur_idx = idx;
 
   // Only threads within local bucket range are active.
   if (threadIdx.x < counters[blockIdx.x]) {
     // Set initial conditions.
-    VTYPE cur_key = key_buf[cur_idx];
+    uint64_t cur_key = key_buf[cur_idx];
     int cur_func = 0;
     int evict_count = 0;
 
@@ -67,9 +63,9 @@ __global__ void cuckooInsertKernel_Multi(
     do {
       int pos = do_2nd_hash(cur_key, hash_func_configs, cur_func, BUCKET_SIZE);
 
-      VTYPE new_data = make_data(cur_idx + 1, cur_func, pos_width);
+      uint64_t new_data = make_data(cur_idx + 1, cur_func, pos_width);
 
-      VTYPE old_idx =
+      uint64_t old_idx =
           atomicExch(&local_key[cur_func * BUCKET_SIZE + pos], new_data);
 
       if (old_idx != EMPTY_CELL) {
@@ -93,7 +89,7 @@ __global__ void cuckooInsertKernel_Multi(
   // Every thread write its responsible local slot into the global data table.
   __syncthreads();
   for (int i = 0; i < num_funcs; ++i) {
-    VTYPE cur_idx = local_key[i * BUCKET_SIZE + threadIdx.x];
+    uint64_t cur_idx = local_key[i * BUCKET_SIZE + threadIdx.x];
     if (cur_idx == EMPTY_CELL) {
       continue;
     }
@@ -105,15 +101,15 @@ __global__ void cuckooInsertKernel_Multi(
 }
 
 __global__ void cuckooLookupKernel_Multi(
-    const VTYPE *const keys, VTYPE *const results, const int n,
-    const VTYPE *const all_keys, const VTYPE *const all_vals, const int size,
-    const FuncConfig *const hash_func_configs, const int num_funcs,
-    const int num_buckets, const int pos_width) {
+    const uint64_t *const keys, uint64_t *const results, const int n,
+    const uint64_t *const all_keys, const uint64_t *const all_vals,
+    const int size, const FuncConfig *const hash_func_configs,
+    const int num_funcs, const int num_buckets, const int pos_width) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
 
   // Only threads within range are active.
   if (idx < n) {
-    VTYPE key = keys[idx];
+    uint64_t key = keys[idx];
     int bucket_num = do_1st_hash(key, num_buckets);
     for (int i = 0; i < num_funcs; ++i) {
       int pos = bucket_num * BUCKET_SIZE +
@@ -129,20 +125,21 @@ __global__ void cuckooLookupKernel_Multi(
   }
 }
 
-void CuckooHashTableCuda_Multi::lookup_vals(const VTYPE *const keys,
-                                            VTYPE *d_key, VTYPE *d_val,
-                                            VTYPE *const results, const int n) {
+void CuckooHashTableCuda_Multi::lookup_vals(const uint64_t *const keys,
+                                            uint64_t *d_key, uint64_t *d_val,
+                                            uint64_t *const results,
+                                            const int n) {
   // Launch the lookup kernel.
   cuckooLookupKernel_Multi<<<ceil((double)n / BUCKET_SIZE), BUCKET_SIZE>>>(
       keys, results, n, d_key, d_val, _size, _d_hash_func_configs, _num_funcs,
       _num_buckets, _pos_width);
 }
 
-int CuckooHashTableCuda_Multi::insert_vals(const VTYPE *const keys,
-                                           const VTYPE *const vals,
-                                           VTYPE *d_key_buf, VTYPE *d_val_buf,
-                                           VTYPE *d_key, VTYPE *d_val,
-                                           const int n) {
+int CuckooHashTableCuda_Multi::insert_vals(const uint64_t *const keys,
+                                           const uint64_t *const vals,
+                                           uint64_t *d_key_buf,
+                                           uint64_t *d_val_buf, uint64_t *d_key,
+                                           uint64_t *d_val, const int n) {
   //
   // Phase 1: Distribute keys into buckets.
   //
@@ -182,7 +179,7 @@ int CuckooHashTableCuda_Multi::insert_vals(const VTYPE *const keys,
     int rehash_requests = 0;
     cudaMemset(d_rehash_requests, 0, sizeof(int));
     cuckooInsertKernel_Multi<<<ceil((double)_size / BUCKET_SIZE), BUCKET_SIZE,
-                               _num_funcs * BUCKET_SIZE * sizeof(VTYPE)>>>(
+                               _num_funcs * BUCKET_SIZE * sizeof(uint64_t)>>>(
         d_key, d_val, d_key_buf, d_val_buf, _size, _d_hash_func_configs,
         _num_funcs, d_counters, _num_buckets, _evict_bound, _pos_width,
         d_rehash_requests);

--- a/torchsparse/backend/hashmap/hashmap_cuda.cu
+++ b/torchsparse/backend/hashmap/hashmap_cuda.cu
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "../utils/atomic.cuh"
 #include "hashmap_cuda.cuh"
 
 __global__ void cuckooBucketKernel_Multi(

--- a/torchsparse/backend/hashmap/hashmap_cuda.cuh
+++ b/torchsparse/backend/hashmap/hashmap_cuda.cuh
@@ -19,8 +19,6 @@
 /** CUDA multi-level thread block size = bucket size. */
 #define BUCKET_SIZE (512)
 
-typedef unsigned long long int VTYPE;
-
 /** Struct of a hash function config. */
 typedef struct {
   int rv;  // Randomized XOR value.
@@ -29,11 +27,11 @@ typedef struct {
 
 /** Hard code hash functions and all inline helper functions for CUDA kernels'
  * use. */
-inline __device__ int do_1st_hash(const VTYPE val, const int num_buckets) {
+inline __device__ int do_1st_hash(const uint64_t val, const int num_buckets) {
   return val % num_buckets;
 }
 
-inline __device__ int do_2nd_hash(const VTYPE val,
+inline __device__ int do_2nd_hash(const uint64_t val,
                                   const FuncConfig *const hash_func_configs,
                                   const int func_idx, const int size) {
   FuncConfig fc = hash_func_configs[func_idx];
@@ -41,16 +39,16 @@ inline __device__ int do_2nd_hash(const VTYPE val,
 }
 
 // trying to ignore EMPTY_CELL by adding 1 at make_data.
-inline __device__ VTYPE fetch_val(const VTYPE data, const int pos_width) {
+inline __device__ uint64_t fetch_val(const uint64_t data, const int pos_width) {
   return data >> pos_width;
 }
 
-inline __device__ int fetch_func(const VTYPE data, const int pos_width) {
+inline __device__ int fetch_func(const uint64_t data, const int pos_width) {
   return data & ((0x1 << pos_width) - 1);
 }
 
-inline __device__ VTYPE make_data(const VTYPE val, const int func,
-                                  const int pos_width) {
+inline __device__ uint64_t make_data(const uint64_t val, const int func,
+                                     const int pos_width) {
   return (val << pos_width) ^ func;
 }
 
@@ -70,7 +68,7 @@ class CuckooHashTableCuda_Multi {
   /** Private operations. */
   void gen_hash_funcs() {
     // Calculate bit width of value range and table size.
-    int val_width = 8 * sizeof(VTYPE) - ceil(log2((double)_num_funcs));
+    int val_width = 8 * sizeof(uint64_t) - ceil(log2((double)_num_funcs));
     int bucket_width = ceil(log2((double)_num_buckets));
     int size_width = ceil(log2((double)BUCKET_SIZE));
     // Generate randomized configurations.
@@ -85,8 +83,8 @@ class CuckooHashTableCuda_Multi {
     }
   };
 
-  inline VTYPE fetch_val(const VTYPE data) { return data >> _pos_width; }
-  inline int fetch_func(const VTYPE data) {
+  inline uint64_t fetch_val(const uint64_t data) { return data >> _pos_width; }
+  inline int fetch_func(const uint64_t data) {
     return data & ((0x1 << _pos_width) - 1);
   }
 
@@ -115,32 +113,30 @@ class CuckooHashTableCuda_Multi {
     if (_d_hash_func_configs != NULL) cudaFree(_d_hash_func_configs);
   };
 
-  int insert_vals(const VTYPE *const keys, const VTYPE *const vals,
-                  VTYPE *d_key_buf, VTYPE *d_val_buf, VTYPE *d_key,
-                  VTYPE *d_val, const int n);
+  int insert_vals(const uint64_t *const keys, const uint64_t *const vals,
+                  uint64_t *d_key_buf, uint64_t *d_val_buf, uint64_t *d_key,
+                  uint64_t *d_val, const int n);
 
-  void lookup_vals(const VTYPE *const keys, VTYPE *const results, VTYPE *d_key,
-                   VTYPE *d_val, const int n);
+  void lookup_vals(const uint64_t *const keys, uint64_t *const results,
+                   uint64_t *d_key, uint64_t *d_val, const int n);
 };
 
-__global__ void cuckooBucketKernel_Multi(VTYPE *const key_buf,
-                                         VTYPE *const val_buf, const int size,
-                                         const VTYPE *const keys,
-                                         const VTYPE *const vals, const int n,
-                                         int *const counters,
-                                         const int num_buckets);
+__global__ void cuckooBucketKernel_Multi(
+    uint64_t *const key_buf, uint64_t *const val_buf, const int size,
+    const uint64_t *const keys, const uint64_t *const vals, const int n,
+    int *const counters, const int num_buckets);
 
 __global__ void cuckooInsertKernel_Multi(
-    VTYPE *const key, VTYPE *const val, const VTYPE *const key_buf,
-    const VTYPE *const val_buf, const int size,
+    uint64_t *const key, uint64_t *const val, const uint64_t *const key_buf,
+    const uint64_t *const val_buf, const int size,
     const FuncConfig *const hash_func_configs, const int num_funcs,
     const int *const counters, const int num_buckets, const int evict_bound,
     const int pos_width, int *const rehash_requests);
 
 __global__ void cuckooLookupKernel_Multi(
-    const VTYPE *const keys, VTYPE *const results, const int n,
-    const VTYPE *const all_keys, const VTYPE *const all_vals, const int size,
-    const FuncConfig *const hash_func_configs, const int num_funcs,
-    const int num_buckets, const int pos_width);
+    const uint64_t *const keys, uint64_t *const results, const int n,
+    const uint64_t *const all_keys, const uint64_t *const all_vals,
+    const int size, const FuncConfig *const hash_func_configs,
+    const int num_funcs, const int num_buckets, const int pos_width);
 
 #endif

--- a/torchsparse/backend/hashmap/hashmap_cuda.cuh
+++ b/torchsparse/backend/hashmap/hashmap_cuda.cuh
@@ -1,5 +1,4 @@
-#ifndef _CUCKOO_CUDA_MULTI_HPP_
-#define _CUCKOO_CUDA_MULTI_HPP_
+#pragma once
 
 #include <cmath>
 #include <cstdint>
@@ -138,5 +137,3 @@ __global__ void cuckooLookupKernel_Multi(
     const uint64_t *const all_keys, const uint64_t *const all_vals,
     const int size, const FuncConfig *const hash_func_configs,
     const int num_funcs, const int num_buckets, const int pos_width);
-
-#endif

--- a/torchsparse/backend/others/count_cpu.h
+++ b/torchsparse/backend/others/count_cpu.h
@@ -1,8 +1,5 @@
-#ifndef _SPARSE_COUNT_CPU
-#define _SPARSE_COUNT_CPU
+#pragma once
 
 #include <torch/torch.h>
 
 at::Tensor count_cpu(const at::Tensor idx, const int s);
-
-#endif

--- a/torchsparse/backend/others/count_cuda.h
+++ b/torchsparse/backend/others/count_cuda.h
@@ -1,8 +1,5 @@
-#ifndef _SPARSE_COUNT
-#define _SPARSE_COUNT
+#pragma once
 
 #include <torch/torch.h>
 
 at::Tensor count_cuda(const at::Tensor idx, const int s);
-
-#endif

--- a/torchsparse/backend/others/query_cpu.cpp
+++ b/torchsparse/backend/others/query_cpu.cpp
@@ -20,16 +20,16 @@ at::Tensor hash_query_cpu(const at::Tensor hash_query,
   at::Tensor out = torch::zeros(
       {n1}, at::device(hash_query.device()).dtype(at::ScalarType::Long));
   for (int idx = 0; idx < n; idx++) {
-    int64_t key = *(hash_target.data_ptr<long>() + idx);
-    int64_t val = *(idx_target.data_ptr<long>() + idx) + 1;
+    int64_t key = *(hash_target.data_ptr<int64_t>() + idx);
+    int64_t val = *(idx_target.data_ptr<int64_t>() + idx) + 1;
     hashmap.insert(std::make_pair(key, val));
   }
 #pragma omp parallel for
   for (int idx = 0; idx < n1; idx++) {
-    int64_t key = *(hash_query.data_ptr<long>() + idx);
+    int64_t key = *(hash_query.data_ptr<int64_t>() + idx);
     google::dense_hash_map<int64_t, int64_t>::iterator iter = hashmap.find(key);
     if (iter != hashmap.end()) {
-      *(out.data_ptr<long>() + idx) = iter->second;
+      *(out.data_ptr<int64_t>() + idx) = iter->second;
     }
   }
 

--- a/torchsparse/backend/others/query_cpu.h
+++ b/torchsparse/backend/others/query_cpu.h
@@ -1,10 +1,7 @@
-#ifndef _SPARSE_QUERY_CPU
-#define _SPARSE_QUERY_CPU
+#pragma once
 
 #include <torch/torch.h>
 
 at::Tensor hash_query_cpu(const at::Tensor hash_query,
                           const at::Tensor hash_target,
                           const at::Tensor idx_target);
-
-#endif

--- a/torchsparse/backend/others/query_cuda.cu
+++ b/torchsparse/backend/others/query_cuda.cu
@@ -38,21 +38,19 @@ at::Tensor hash_query_cuda(const at::Tensor hash_query,
       torch::zeros({num_funcs * table_size},
                    at::device(hash_query.device()).dtype(at::ScalarType::Long));
 
-  in_hash_table.insert_vals(
-      (unsigned long long int *)(hash_target.data_ptr<long>()),
-      (unsigned long long int *)(idx_target.data_ptr<long>()),
-      (unsigned long long int *)(key_buf.data_ptr<long>()),
-      (unsigned long long int *)(val_buf.data_ptr<long>()),
-      (unsigned long long int *)(key.data_ptr<long>()),
-      (unsigned long long int *)(val.data_ptr<long>()), n);
+  in_hash_table.insert_vals((uint64_t *)(hash_target.data_ptr<int64_t>()),
+                            (uint64_t *)(idx_target.data_ptr<int64_t>()),
+                            (uint64_t *)(key_buf.data_ptr<int64_t>()),
+                            (uint64_t *)(val_buf.data_ptr<int64_t>()),
+                            (uint64_t *)(key.data_ptr<int64_t>()),
+                            (uint64_t *)(val.data_ptr<int64_t>()), n);
 
   at::Tensor out = torch::zeros(
       {n1}, at::device(hash_query.device()).dtype(at::ScalarType::Long));
 
-  in_hash_table.lookup_vals(
-      (unsigned long long int *)(hash_query.data_ptr<long>()),
-      (unsigned long long int *)(key.data_ptr<long>()),
-      (unsigned long long int *)(val.data_ptr<long>()),
-      (unsigned long long int *)(out.data_ptr<long>()), n1);
+  in_hash_table.lookup_vals((uint64_t *)(hash_query.data_ptr<int64_t>()),
+                            (uint64_t *)(key.data_ptr<int64_t>()),
+                            (uint64_t *)(val.data_ptr<int64_t>()),
+                            (uint64_t *)(out.data_ptr<int64_t>()), n1);
   return out;
 }

--- a/torchsparse/backend/others/query_cuda.h
+++ b/torchsparse/backend/others/query_cuda.h
@@ -1,10 +1,7 @@
-#ifndef _SPARSE_QUERY
-#define _SPARSE_QUERY
+#pragma once
 
 #include <torch/torch.h>
 
 at::Tensor hash_query_cuda(const at::Tensor hash_query,
                            const at::Tensor hash_target,
                            const at::Tensor idx_target);
-
-#endif

--- a/torchsparse/backend/utils/atomic.cuh
+++ b/torchsparse/backend/utils/atomic.cuh
@@ -1,0 +1,6 @@
+#pragma once
+
+__device__ static uint64_t atomicExch(uint64_t *addr, uint64_t val) {
+  return (uint64_t)atomicExch((unsigned long long int *)addr,
+                              (unsigned long long int)val);
+}

--- a/torchsparse/backend/voxelize/voxelize_cpu.h
+++ b/torchsparse/backend/voxelize/voxelize_cpu.h
@@ -1,5 +1,4 @@
-#ifndef TORCHSPARSE_VOXELIZE_CPU
-#define TORCHSPARSE_VOXELIZE_CPU
+#pragma once
 
 #include <torch/torch.h>
 
@@ -9,5 +8,3 @@ at::Tensor voxelize_forward_cpu(const at::Tensor inputs, const at::Tensor idx,
 at::Tensor voxelize_backward_cpu(const at::Tensor top_grad,
                                  const at::Tensor idx, const at::Tensor counts,
                                  const int N);
-
-#endif

--- a/torchsparse/backend/voxelize/voxelize_cuda.h
+++ b/torchsparse/backend/voxelize/voxelize_cuda.h
@@ -1,5 +1,4 @@
-#ifndef TORCHSPARSE_VOXELIZE_CUDA
-#define TORCHSPARSE_VOXELIZE_CUDA
+#pragma once
 
 #include <torch/torch.h>
 
@@ -9,5 +8,3 @@ at::Tensor voxelize_forward_cuda(const at::Tensor inputs, const at::Tensor idx,
 at::Tensor voxelize_backward_cuda(const at::Tensor top_grad,
                                   const at::Tensor idx, const at::Tensor counts,
                                   const int N);
-
-#endif

--- a/torchsparse/nn/functional/conv.py
+++ b/torchsparse/nn/functional/conv.py
@@ -44,6 +44,10 @@ class ConvolutionFunction(Function):
         if input.device.type == 'cuda':
             torchsparse.backend.convolution_forward_cuda(
                 input, output, weight, nbmaps, nbsizes.cpu(), transposed)
+        elif input.device.type == 'cpu':
+            torchsparse.backend.convolution_forward_cpu(input, output, weight,
+                                                        nbmaps, nbsizes.cpu(),
+                                                        transposed)
         else:
             # use the native pytorch XLA APIs for the TPU.
             cur_st = 0
@@ -73,6 +77,10 @@ class ConvolutionFunction(Function):
 
         if grad_output.device.type == 'cuda':
             torchsparse.backend.convolution_backward_cuda(
+                input, grad_input, grad_output.contiguous(), weight,
+                grad_weight, nbmaps, nbsizes.cpu(), transposed)
+        elif grad_output.device.type == 'cpu':
+            torchsparse.backend.convolution_backward_cpu(
                 input, grad_input, grad_output.contiguous(), weight,
                 grad_weight, nbmaps, nbsizes.cpu(), transposed)
         else:

--- a/torchsparse/tensor.py
+++ b/torchsparse/tensor.py
@@ -43,19 +43,24 @@ class SparseTensor:
     def s(self, stride: Union[int, Tuple[int, ...]]) -> None:
         self.stride = make_ntuple(stride, ndim=3)
 
+    def cpu(self):
+        self.coords = self.coords.cpu()
+        self.feats = self.feats.cpu()
+        return self
+
     def cuda(self):
-        self.feats = self.feats.cuda()
         self.coords = self.coords.cuda()
+        self.feats = self.feats.cuda()
         return self
 
     def detach(self):
-        self.feats = self.feats.detach()
         self.coords = self.coords.detach()
+        self.feats = self.feats.detach()
         return self
 
     def to(self, device: str, non_blocking: bool = True):
-        self.feats = self.feats.to(device, non_blocking=non_blocking)
         self.coords = self.coords.to(device, non_blocking=non_blocking)
+        self.feats = self.feats.to(device, non_blocking=non_blocking)
         return self
 
     def __add__(self, other):


### PR DESCRIPTION
This PR adds support for Mac OS. The main change is to replace `long long` with `int64_t` and `unsigned long long` with `uint64_t`.