### PR TITLE
Update downsample.py

### DIFF
--- a/torchsparse/nn/functional/downsample.py
+++ b/torchsparse/nn/functional/downsample.py
@@ -24,7 +24,8 @@ def spdownsample(
 
     if all(stride[k] in [1, kernel_size[k]] for k in range(3)):
         coords = coords.clone()
-        coords[:, :3] = coords[:, :3] // sample_stride * sample_stride
+        # coords[:, :3] = coords[:, :3] // sample_stride * sample_stride # 
+        coords[:, :3] = torch.div(coords[:, :3], sample_stride, rounding_mode='floor') * sample_stride
     else:
         offsets = get_kernel_offsets(kernel_size,
                                      tensor_stride,

--- a/torchsparse/nn/functional/downsample.py
+++ b/torchsparse/nn/functional/downsample.py
@@ -24,8 +24,8 @@ def spdownsample(
 
     if all(stride[k] in [1, kernel_size[k]] for k in range(3)):
         coords = coords.clone()
-        # coords[:, :3] = coords[:, :3] // sample_stride * sample_stride # 
-        coords[:, :3] = torch.div(coords[:, :3], sample_stride, rounding_mode='floor') * sample_stride
+        coords[:, :3] = torch.div(
+            coords[:, :3], sample_stride, rounding_mode='floor') * sample_stride
     else:
         offsets = get_kernel_offsets(kernel_size,
                                      tensor_stride,

--- a/torchsparse/nn/functional/downsample.py
+++ b/torchsparse/nn/functional/downsample.py
@@ -25,7 +25,7 @@ def spdownsample(
     if all(stride[k] in [1, kernel_size[k]] for k in range(3)):
         coords = coords.clone()
         coords[:, :3] = torch.div(
-            coords[:, :3], sample_stride, rounding_mode='floor') * sample_stride
+            coords[:, :3], sample_stride, rounding_mode='trunc') * sample_stride
     else:
         offsets = get_kernel_offsets(kernel_size,
                                      tensor_stride,

--- a/torchsparse/nn/modules/bev.py
+++ b/torchsparse/nn/modules/bev.py
@@ -89,10 +89,10 @@ class ToDenseBEVConvolution(nn.Module):
         kernel = torch.index_select(
             self.kernel, 0,
             torch.div(coords[:, self.dim], stride,
-                      rounding_mode='floor').long())
+                      rounding_mode='trunc').long())
         feats = (feats.unsqueeze(dim=-1) * kernel).sum(1) + self.bias
         coords = (coords - self.offset).t()[[3] + self.bev_dims].long()
-        coords[1:] = torch.div(coords[1:], stride, rounding_mode='floor').long()
+        coords[1:] = torch.div(coords[1:], stride, rounding_mode='trunc').long()
         indices = coords[0] * int(self.bev_shape.prod()) + coords[1] * int(
             self.bev_shape[1]) + coords[2]
         batch_size = coords[0].max().item() + 1
@@ -145,7 +145,7 @@ class ToBEVConvolution(nn.Module):
         kernels = torch.index_select(
             self.kernel, 0,
             torch.div(coords[:, self.dim].long(), stride,
-                      rounding_mode='floor'))
+                      rounding_mode='trunc'))
         feats = (feats.unsqueeze(dim=-1) * kernels).sum(1) + self.bias
         coords = coords.t().long()
         coords[self.dim, :] = 0
@@ -199,7 +199,7 @@ class ToBEVHeightCompression(nn.Module):
         # now stride must be torch.Tensor since input.s is tuple.
         stride = stride[:, self.bev_dims + [self.dim]].t()
 
-        coords[1:] = torch.div(coords[1:], stride, rounding_mode='floor').long()
+        coords[1:] = torch.div(coords[1:], stride, rounding_mode='trunc').long()
         coords[-1] = torch.clamp(coords[-1], 0, shape[-1] - 1)
         indices = coords[0] * int(shape.prod()) + coords[1] * int(
             shape[1:].prod()) + coords[2] * int(shape[2]) + coords[3]

--- a/torchsparse/nn/modules/bev.py
+++ b/torchsparse/nn/modules/bev.py
@@ -86,11 +86,13 @@ class ToDenseBEVConvolution(nn.Module):
         coords, feats, stride = input.coords, input.feats, input.stride
         stride = torch.tensor(stride).unsqueeze(dim=0).to(feats)[:, self.dim]
 
-        kernel = torch.index_select(self.kernel, 0,
-                                    (coords[:, self.dim] // stride).long())
+        kernel = torch.index_select(
+            self.kernel, 0,
+            torch.div(coords[:, self.dim], stride,
+                      rounding_mode='floor').long())
         feats = (feats.unsqueeze(dim=-1) * kernel).sum(1) + self.bias
         coords = (coords - self.offset).t()[[3] + self.bev_dims].long()
-        coords[1:] = (coords[1:] // stride).long()
+        coords[1:] = torch.div(coords[1:], stride, rounding_mode='floor').long()
         indices = coords[0] * int(self.bev_shape.prod()) + coords[1] * int(
             self.bev_shape[1]) + coords[2]
         batch_size = coords[0].max().item() + 1
@@ -140,8 +142,10 @@ class ToBEVConvolution(nn.Module):
         ratio = stride * self.stride
         stride = torch.tensor(stride).unsqueeze(dim=0).to(feats)[:, self.dim]
 
-        kernels = torch.index_select(self.kernel, 0,
-                                     coords[:, self.dim].long() // stride)
+        kernels = torch.index_select(
+            self.kernel, 0,
+            torch.div(coords[:, self.dim].long(), stride,
+                      rounding_mode='floor'))
         feats = (feats.unsqueeze(dim=-1) * kernels).sum(1) + self.bias
         coords = coords.t().long()
         coords[self.dim, :] = 0
@@ -195,7 +199,7 @@ class ToBEVHeightCompression(nn.Module):
         # now stride must be torch.Tensor since input.s is tuple.
         stride = stride[:, self.bev_dims + [self.dim]].t()
 
-        coords[1:] = (coords[1:] // stride).long()
+        coords[1:] = torch.div(coords[1:], stride, rounding_mode='floor').long()
         coords[-1] = torch.clamp(coords[-1], 0, shape[-1] - 1)
         indices = coords[0] * int(shape.prod()) + coords[1] * int(
             shape[1:].prod()) + coords[2] * int(shape[2]) + coords[3]


### PR DESCRIPTION
UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').