### PR TITLE
 Fix the coordinate cache when `stride > 1`

### DIFF
--- a/torchsparse/nn/functional/conv.py
+++ b/torchsparse/nn/functional/conv.py
@@ -17,59 +17,76 @@ class ConvolutionFunction(Function):
 
     @staticmethod
     @custom_fwd(cast_inputs=torch.half)
-    def forward(ctx,
-                input: torch.Tensor,
-                weight: torch.Tensor,
-                nbmaps: torch.Tensor,
-                nbsizes: torch.Tensor,
-                sizes: Tuple[int, int],
-                transposed: bool = False) -> torch.Tensor:
+    def forward(
+        ctx,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        nbmaps: torch.Tensor,
+        nbsizes: torch.Tensor,
+        sizes: Tuple[int, int],
+        transposed: bool = False,
+    ) -> torch.Tensor:
         input = input.contiguous()
         weight = weight.contiguous()
         nbmaps = nbmaps.int().contiguous()
         nbsizes = nbsizes.int().contiguous()
 
         if not transposed:
-            output = torch.zeros(sizes[1],
-                                 weight.size(-1),
-                                 dtype=input.dtype,
-                                 device=input.device)
+            output = torch.zeros(
+                sizes[1],
+                weight.size(-1),
+                dtype=input.dtype,
+                device=input.device,
+            )
         else:
             # TODO(Haotian): ensure the original, upsampled size to be the same.
-            output = torch.zeros(sizes[0],
-                                 weight.size(-1),
-                                 dtype=input.dtype,
-                                 device=input.device)
+            output = torch.zeros(
+                sizes[0],
+                weight.size(-1),
+                dtype=input.dtype,
+                device=input.device,
+            )
 
         if input.device.type == 'cuda':
             torchsparse.backend.convolution_forward_cuda(
-                input, output, weight, nbmaps, nbsizes.cpu(), transposed)
+                input,
+                output,
+                weight,
+                nbmaps,
+                nbsizes.cpu(),
+                transposed,
+            )
         elif input.device.type == 'cpu':
-            torchsparse.backend.convolution_forward_cpu(input, output, weight,
-                                                        nbmaps, nbsizes.cpu(),
-                                                        transposed)
+            torchsparse.backend.convolution_forward_cpu(
+                input,
+                output,
+                weight,
+                nbmaps,
+                nbsizes.cpu(),
+                transposed,
+            )
         else:
-            # use the native pytorch XLA APIs for the TPU.
             cur_st = 0
-            for kernel_idx in range(weight.shape[0]):
-                cur_ed = cur_st + nbsizes[kernel_idx]
-                in_map = nbmaps[cur_st:cur_ed, 0].long()
-                out_map = nbmaps[cur_st:cur_ed, 1].long()
-                cur_st += nbsizes[kernel_idx]
+            for k in range(weight.shape[0]):
+                cur_ed = cur_st + nbsizes[k]
+                imap = nbmaps[cur_st:cur_ed, 0].long()
+                omap = nbmaps[cur_st:cur_ed, 1].long()
+                cur_st += nbsizes[k]
 
                 if transposed:
-                    in_map, out_map = out_map, in_map
+                    imap, omap = omap, imap
 
-                cur_feat = input[in_map]
-                cur_feat = torch.mm(cur_feat, weight[kernel_idx])
-                output[out_map] += cur_feat
+                output[omap] += torch.mm(input[imap], weight[k])
 
         ctx.for_backwards = (input, weight, nbmaps, nbsizes, transposed)
         return output
 
     @staticmethod
     @custom_bwd
-    def backward(ctx, grad_output: torch.Tensor):
+    def backward(
+        ctx,
+        grad_output: torch.Tensor,
+    ) -> Tuple[Optional[torch.Tensor], ...]:
         input, weight, nbmaps, nbsizes, transposed = ctx.for_backwards
 
         grad_input = torch.zeros_like(input)
@@ -77,80 +94,112 @@ class ConvolutionFunction(Function):
 
         if grad_output.device.type == 'cuda':
             torchsparse.backend.convolution_backward_cuda(
-                input, grad_input, grad_output.contiguous(), weight,
-                grad_weight, nbmaps, nbsizes.cpu(), transposed)
+                input,
+                grad_input,
+                grad_output.contiguous(),
+                weight,
+                grad_weight,
+                nbmaps,
+                nbsizes.cpu(),
+                transposed,
+            )
         elif grad_output.device.type == 'cpu':
             torchsparse.backend.convolution_backward_cpu(
-                input, grad_input, grad_output.contiguous(), weight,
-                grad_weight, nbmaps, nbsizes.cpu(), transposed)
+                input,
+                grad_input,
+                grad_output.contiguous(),
+                weight,
+                grad_weight,
+                nbmaps,
+                nbsizes.cpu(),
+                transposed,
+            )
         else:
             raise NotImplementedError
         return grad_input, grad_weight, None, None, None, None
 
 
-def conv3d(input: SparseTensor,
-           weight: torch.Tensor,
-           kernel_size: Union[int, Tuple[int, ...]],
-           bias: Optional[torch.Tensor] = None,
-           stride: Union[int, Tuple[int, ...]] = 1,
-           dilation: Union[int, Tuple[int, ...]] = 1,
-           transposed: bool = False) -> SparseTensor:
-    feats, coords = input.feats, input.coords
-
+def conv3d(
+    input: SparseTensor,
+    weight: torch.Tensor,
+    kernel_size: Union[int, Tuple[int, ...]],
+    bias: Optional[torch.Tensor] = None,
+    stride: Union[int, Tuple[int, ...]] = 1,
+    dilation: Union[int, Tuple[int, ...]] = 1,
+    transposed: bool = False,
+) -> SparseTensor:
     kernel_size = make_ntuple(kernel_size, ndim=3)
     stride = make_ntuple(stride, ndim=3)
     dilation = make_ntuple(dilation, ndim=3)
 
-    if (kernel_size == (1, 1, 1) and stride == (1, 1, 1)
-            and dilation == (1, 1, 1)):
-        feats = feats.matmul(weight)
-        if bias is not None:
-            feats += bias
-        output = SparseTensor(coords=coords, feats=feats, stride=input.stride)
+    if (kernel_size == make_ntuple(1, ndim=3)
+            and stride == make_ntuple(1, ndim=3)
+            and dilation == make_ntuple(1, ndim=3)):
+        output_stride = input.stride
+        output_coords = input.coords
+        output_feats = input.feats.matmul(weight)
     elif not transposed:
-        kmap = input.kmaps.get((input.stride, kernel_size, stride, dilation))
-        if kmap is None:
-            offsets = get_kernel_offsets(kernel_size,
-                                         stride=input.stride,
-                                         dilation=dilation,
-                                         device=feats.device)
+        output_stride = tuple(input.stride[k] * stride[k] for k in range(3))
 
-            references = F.sphash(coords)
-            if any(s > 1 for s in stride):
-                coords = F.spdownsample(coords, stride, kernel_size,
-                                        input.stride)
-            queries = F.sphash(coords, offsets)
+        if output_stride in input.cmaps:
+            output_coords = input.cmaps[output_stride]
+        elif all(stride[k] == 1 for k in range(3)):
+            output_coords = input.coords
+        else:
+            output_coords = F.spdownsample(
+                input.coords,
+                stride,
+                kernel_size,
+                input.stride,
+            )
+
+        if (input.stride, kernel_size, stride, dilation) not in input.kmaps:
+            offsets = get_kernel_offsets(
+                kernel_size,
+                stride=input.stride,
+                dilation=dilation,
+                device=input.feats.device,
+            )
+
+            references = F.sphash(input.coords)
+            queries = F.sphash(output_coords, offsets)
             results = F.sphashquery(queries, references)
 
             nbsizes = torch.sum(results != -1, dim=1)
             nbmaps = torch.nonzero(results != -1)
-            nbmaps[:, 0] = results.view(-1)[nbmaps[:, 0] * results.size(1)
-                                            + nbmaps[:, 1]]
 
-            kmap = [nbmaps, nbsizes, (feats.shape[0], coords.shape[0])]
-            input.kmaps[(input.stride, kernel_size, stride, dilation)] = kmap
+            indices = nbmaps[:, 0] * results.size(1) + nbmaps[:, 1]
+            nbmaps[:, 0] = results.view(-1)[indices]
 
-        feats = ConvolutionFunction.apply(feats, weight, kmap[0], kmap[1],
-                                          kmap[2], transposed)
-        if bias is not None:
-            feats += bias
-        output = SparseTensor(
-            coords=coords,
-            feats=feats,
-            stride=tuple(input.stride[k] * stride[k] for k in range(3)))
+            input.kmaps[(input.stride, kernel_size, stride, dilation)] = [
+                nbmaps, nbsizes, (input.feats.shape[0], input.coords.shape[0])
+            ]
+
+        output_feats = ConvolutionFunction.apply(
+            input.feats,
+            weight,
+            *input.kmaps[(input.stride, kernel_size, stride, dilation)],
+            transposed,
+        )
     else:
-        tensor_stride = tuple(input.stride[k] // stride[k] for k in range(3))
-        kmap = input.kmaps[(tensor_stride, kernel_size, stride, dilation)]
+        output_stride = tuple(input.stride[k] // stride[k] for k in range(3))
+        output_coords = input.cmaps[output_stride]
+        output_feats = ConvolutionFunction.apply(
+            input.feats,
+            weight,
+            *input.kmaps[(output_stride, kernel_size, stride, dilation)],
+            transposed,
+        )
 
-        feats = ConvolutionFunction.apply(feats, weight, kmap[0], kmap[1],
-                                          kmap[2], transposed)
-        if bias is not None:
-            feats += bias
-        output = SparseTensor(coords=input.cmaps[tensor_stride],
-                              feats=feats,
-                              stride=tensor_stride)
+    if bias is not None:
+        output_feats += bias
 
+    output = SparseTensor(
+        coords=output_coords,
+        feats=output_feats,
+        stride=output_stride,
+    )
     output.cmaps = input.cmaps
-    output.cmaps.setdefault(output.stride, output.coords)
+    output.cmaps.setdefault(output_stride, output_coords)
     output.kmaps = input.kmaps
     return output


### PR DESCRIPTION
This PR fixes the coordinate cache when `stride > 1` (which is described in https://github.com/mit-han-lab/torchsparse/issues/116).