### PR TITLE
Update `pre-commit` to avoid installing `clang-format` locally

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,9 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends clang-format
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,17 +52,23 @@ repos:
     hooks:
       - id: flake8
         name: (Python) Check with flake8
-        additional_dependencies: [flake8-bugbear, flake8-comprehensions, flake8-docstrings, flake8-executable, flake8-quotes]
+        additional_dependencies:
+          - flake8-bugbear
+          - flake8-comprehensions
+          - flake8-docstrings
+          - flake8-executable
+          - flake8-quotes
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.902
     hooks:
       - id: mypy
         name: (Python) Check with mypy
-        additional_dependencies: [tokenize-rt]
-  - repo: local
+        additional_dependencies:
+          - tokenize-rt
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.0
     hooks:
       - id: clang-format
         name: (C/C++/CUDA) Format with clang-format
-        entry: clang-format -style=google -i
-        language: system
-        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+        types_or: [c, c++, cuda]
+        args: ['-style=google', '-i']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         name: (Common) Remove trailing whitespaces
       - id: mixed-line-ending
         name: (Common) Fix mixed line ending
-        args: ['--fix=lf']
+        args: [--fix=lf]
       - id: end-of-file-fixer
         name: (Common) Remove extra EOF newlines
       - id: check-merge-conflict
@@ -15,7 +15,7 @@ repos:
         name: (Common) Sort "requirements.txt"
       - id: fix-encoding-pragma
         name: (Python) Remove encoding pragmas
-        args: ['--remove']
+        args: [--remove]
       - id: double-quote-string-fixer
         name: (Python) Fix double-quoted strings
       - id: debug-statements
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: (Python) Update syntax for newer versions
-        args: ['--py36-plus']
+        args: [--py36-plus]
   - repo: https://github.com/google/yapf
     rev: v0.31.0
     hooks:
@@ -65,10 +65,12 @@ repos:
         name: (Python) Check with mypy
         additional_dependencies:
           - tokenize-rt
+          - types-pyyaml
+          - types-toml
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.0
     hooks:
       - id: clang-format
         name: (C/C++/CUDA) Format with clang-format
         types_or: [c, c++, cuda]
-        args: ['-style=google', '-i']
+        args: [-style=google, -i]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,5 +72,5 @@ repos:
     hooks:
       - id: clang-format
         name: (C/C++/CUDA) Format with clang-format
-        types_or: [c, c++, cuda]
         args: [-style=google, -i]
+        types_or: [c, c++, cuda]


### PR DESCRIPTION
This PR updates `pre-commit` to avoid installing `clang-format` locally.