### PR TITLE
Fix integer division error

### DIFF
--- a/torchsparse/nn/functional/downsample.py
+++ b/torchsparse/nn/functional/downsample.py
@@ -24,8 +24,9 @@ def spdownsample(
 
     if all(stride[k] in [1, kernel_size[k]] for k in range(3)):
         coords = coords.clone()
-        coords[:, :3] = torch.div(coords[:, :3],
-                                  sample_stride.float()).trunc() * sample_stride  # type: ignore
+        coords[:, :3] = torch.div(
+            coords[:, :3],
+            sample_stride.float()).trunc() * sample_stride  # type: ignore
     else:
         offsets = get_kernel_offsets(kernel_size,
                                      tensor_stride,

--- a/torchsparse/nn/functional/downsample.py
+++ b/torchsparse/nn/functional/downsample.py
@@ -25,7 +25,7 @@ def spdownsample(
     if all(stride[k] in [1, kernel_size[k]] for k in range(3)):
         coords = coords.clone()
         coords[:, :3] = torch.div(coords[:, :3],
-                                  sample_stride).trunc() * sample_stride
+                                  sample_stride.float()).trunc() * sample_stride
     else:
         offsets = get_kernel_offsets(kernel_size,
                                      tensor_stride,

--- a/torchsparse/nn/functional/downsample.py
+++ b/torchsparse/nn/functional/downsample.py
@@ -25,7 +25,7 @@ def spdownsample(
     if all(stride[k] in [1, kernel_size[k]] for k in range(3)):
         coords = coords.clone()
         coords[:, :3] = torch.div(coords[:, :3],
-                                  sample_stride.float()).trunc() * sample_stride
+                                  sample_stride.float()).trunc() * sample_stride  # type: ignore
     else:
         offsets = get_kernel_offsets(kernel_size,
                                      tensor_stride,


### PR DESCRIPTION
In PyTorch 1.7.0 integer division of tensors using div or / is no longer
supported. Therefore, to avoid this error, convert sample_stride to
float type.