### PR TITLE
Support cached_property for python version < 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+backports.cached_property
+numpy
+tqdm
+typing-extensions
+wheel

--- a/torchsparse/nn/modules/conv.py
+++ b/torchsparse/nn/modules/conv.py
@@ -1,6 +1,11 @@
 import math
-from functools import cached_property
+import sys
 from typing import Dict, List, Tuple, Union
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from backports.cached_property import cached_property
 
 import numpy as np
 import torch


### PR DESCRIPTION
`functools.cached_property` is only available in python 3.8 and later versions. This PR adds support for the `@cached_property` decorator used in `nn.Conv3d` for previous python versions. 
Note: a new dependency needs to be installed by running `pip install backports.cached_property`.