### PR TITLE
AttributeError: 'torch.dtype' object has no attribute 'long'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TorchSparse
+# TorchSparse - for windows
 
 TorchSparse is a high-performance neural network library for point cloud processing.
 

--- a/torchsparse/backend/hash/hash_cpu.cpp
+++ b/torchsparse/backend/hash/hash_cpu.cpp
@@ -4,10 +4,10 @@
 
 #include <vector>
 
-void cpu_hash_wrapper(int N, const int *data, int64_t *out) {
+void cpu_hash_wrapper(int N, const int64_t *data, int64_t *out) {
 #pragma omp parallel for
   for (int i = 0; i < N; i++) {
-    uint64_t hash = 14695981039346656037UL;
+    unsigned long long hash = 14695981039346656037UL;
     for (int j = 0; j < 4; j++) {
       hash ^= (unsigned int)data[4 * i + j];
       hash *= 1099511628211UL;
@@ -17,8 +17,8 @@ void cpu_hash_wrapper(int N, const int *data, int64_t *out) {
   }
 }
 
-void cpu_kernel_hash_wrapper(int N, int K, const int *data,
-                             const int *kernel_offset, int64_t *out) {
+void cpu_kernel_hash_wrapper(int N, int K, const int64_t *data,
+                             const int64_t *kernel_offset, int64_t *out) {
   for (int k = 0; k < K; k++) {
 #pragma omp parallel for
     for (int i = 0; i < N; i++) {
@@ -26,8 +26,8 @@ void cpu_kernel_hash_wrapper(int N, int K, const int *data,
       for (int j = 0; j < 3; j++) {
         cur_coord[j] = data[i * 4 + j] + kernel_offset[k * 3 + j];
       }
-      cur_coord[3] = data[i * 4 + 3];
-      uint64_t hash = 14695981039346656037UL;
+      cur_coord[3] = data[3];
+      unsigned long long hash = 14695981039346656037UL;
       for (int j = 0; j < 4; j++) {
         hash ^= (unsigned int)cur_coord[j];
         hash *= 1099511628211UL;
@@ -42,7 +42,7 @@ at::Tensor hash_cpu(const at::Tensor idx) {
   int N = idx.size(0);
   at::Tensor out =
       torch::zeros({N}, at::device(idx.device()).dtype(at::ScalarType::Long));
-  cpu_hash_wrapper(N, idx.data_ptr<int>(), out.data_ptr<int64_t>());
+  cpu_hash_wrapper(N, idx.data_ptr<int64_t>(), out.data_ptr<int64_t>());
   return out;
 }
 
@@ -52,8 +52,7 @@ at::Tensor kernel_hash_cpu(const at::Tensor idx,
   int K = kernel_offset.size(0);
   at::Tensor out = torch::zeros(
       {K, N}, at::device(idx.device()).dtype(at::ScalarType::Long));
-  cpu_kernel_hash_wrapper(N, K, idx.data_ptr<int>(),
-                          kernel_offset.data_ptr<int>(),
-                          out.data_ptr<int64_t>());
+  cpu_kernel_hash_wrapper(N, K, idx.data_ptr<int64_t>(),
+                          kernel_offset.data_ptr<int64_t>(), out.data_ptr<int64_t>());
   return out;
 }

--- a/torchsparse/backend/hash/hash_cuda.cu
+++ b/torchsparse/backend/hash/hash_cuda.cu
@@ -12,7 +12,7 @@ __global__ void hash_kernel(int N, const int *__restrict__ data,
   int i = blockDim.x * blockIdx.x + threadIdx.x;
   if (i < N) {
     data += i * 4;
-    uint64_t hash = 14695981039346656037UL;
+    unsigned long long hash = 14695981039346656037UL;
     for (int j = 0; j < 4; j++) {
       hash ^= (unsigned int)data[j];
       hash *= 1099511628211UL;
@@ -44,7 +44,7 @@ __global__ void kernel_hash_kernel(int N, int K, const int *__restrict__ data,
       cur_coord[j] = data[j] + kernel_offset[k * 3 + j];
     }
     cur_coord[3] = data[3];
-    uint64_t hash = 14695981039346656037UL;
+    unsigned long long hash = 14695981039346656037UL;
     for (int j = 0; j < 4; j++) {
       hash ^= (unsigned int)cur_coord[j];
       hash *= 1099511628211UL;

--- a/torchsparse/backend/others/query_cuda.cu
+++ b/torchsparse/backend/others/query_cuda.cu
@@ -38,19 +38,21 @@ at::Tensor hash_query_cuda(const at::Tensor hash_query,
       torch::zeros({num_funcs * table_size},
                    at::device(hash_query.device()).dtype(at::ScalarType::Long));
 
-  in_hash_table.insert_vals((uint64_t *)(hash_target.data_ptr<int64_t>()),
-                            (uint64_t *)(idx_target.data_ptr<int64_t>()),
-                            (uint64_t *)(key_buf.data_ptr<int64_t>()),
-                            (uint64_t *)(val_buf.data_ptr<int64_t>()),
-                            (uint64_t *)(key.data_ptr<int64_t>()),
-                            (uint64_t *)(val.data_ptr<int64_t>()), n);
+  in_hash_table.insert_vals(
+      (unsigned long long int *)(hash_target.data_ptr<int64_t>()),
+      (unsigned long long int *)(idx_target.data_ptr<int64_t>()),
+      (unsigned long long int *)(key_buf.data_ptr<int64_t>()),
+      (unsigned long long int *)(val_buf.data_ptr<int64_t>()),
+      (unsigned long long int *)(key.data_ptr<int64_t>()),
+      (unsigned long long int *)(val.data_ptr<int64_t>()), n);
 
   at::Tensor out = torch::zeros(
       {n1}, at::device(hash_query.device()).dtype(at::ScalarType::Long));
 
-  in_hash_table.lookup_vals((uint64_t *)(hash_query.data_ptr<int64_t>()),
-                            (uint64_t *)(key.data_ptr<int64_t>()),
-                            (uint64_t *)(val.data_ptr<int64_t>()),
-                            (uint64_t *)(out.data_ptr<int64_t>()), n1);
+  in_hash_table.lookup_vals(
+      (unsigned long long int *)(hash_query.data_ptr<int64_t>()),
+      (unsigned long long int *)(key.data_ptr<int64_t>()),
+      (unsigned long long int *)(val.data_ptr<int64_t>()),
+      (unsigned long long int *)(out.data_ptr<int64_t>()), n1);
   return out;
 }


### PR DESCRIPTION
  File "E:\Anaconda\envs\cunet\lib\site-packages\torchsparse-2.0.0b0-py3.8-win-amd64.egg\torchsparse\nn\functional\hash.py", line 12, in sphash
    assert coords.dtype == torch.int.long(), coords.dtype
AttributeError: 'torch.dtype' object has no attribute 'long'

Although torchsparse was successfully installed on windows, errors were still reported at runtime.