### PR TITLE
Fix batch_size

### DIFF
--- a/torchsparse/nn/functional/pooling.py
+++ b/torchsparse/nn/functional/pooling.py
@@ -6,10 +6,10 @@ __all__ = ['global_avg_pool', 'global_max_pool']
 
 
 def global_avg_pool(inputs: SparseTensor) -> torch.Tensor:
-    batch_size = torch.max(inputs.coords[:, -1]).item() + 1
+    batch_size = torch.max(inputs.coords[:, 0]).item() + 1
     outputs = []
     for k in range(batch_size):
-        input = inputs.feats[inputs.coords[:, -1] == k]
+        input = inputs.feats[inputs.coords[:, 0] == k]
         output = torch.mean(input, dim=0)
         outputs.append(output)
     outputs = torch.stack(outputs, dim=0)
@@ -17,10 +17,10 @@ def global_avg_pool(inputs: SparseTensor) -> torch.Tensor:
 
 
 def global_max_pool(inputs: SparseTensor) -> torch.Tensor:
-    batch_size = torch.max(inputs.coords[:, -1]).item() + 1
+    batch_size = torch.max(inputs.coords[:, 0]).item() + 1
     outputs = []
     for k in range(batch_size):
-        input = inputs.feats[inputs.coords[:, -1] == k]
+        input = inputs.feats[inputs.coords[:, 0] == k]
         output = torch.max(input, dim=0)[0]
         outputs.append(output)
     outputs = torch.stack(outputs, dim=0)

--- a/torchsparse/nn/modules/norm.py
+++ b/torchsparse/nn/modules/norm.py
@@ -18,7 +18,7 @@ class GroupNorm(nn.GroupNorm):
     def forward(self, input: SparseTensor) -> SparseTensor:
         coords, feats, stride = input.coords, input.feats, input.stride
 
-        batch_size = torch.max(coords[:, -1]).item() + 1
+        batch_size = torch.max(coords[:, 0]).item() + 1
         num_channels = feats.shape[1]
 
         # PyTorch's GroupNorm function expects the input to be in (N, C, *)


### PR DESCRIPTION
TorchSparse v2.1 changed the coordinate order from [x, y, z, batch] to [batch, x, y, z]. The batch_size acquisition method needs to be modified