### PR TITLE
Fixed GroupNorm

### DIFF
--- a/torchsparse/nn/modules/norm.py
+++ b/torchsparse/nn/modules/norm.py
@@ -18,7 +18,7 @@ class GroupNorm(nn.GroupNorm):
     def forward(self, input: SparseTensor) -> SparseTensor:
         coords, feats, stride = input.coords, input.feats, input.stride
 
-        batch_size = torch.max(coords[:, -1]).item() + 1
+        batch_size = torch.max(coords[:, 0]).item() + 1
         num_channels = feats.shape[1]
 
         # PyTorch's GroupNorm function expects the input to be in (N, C, *)
@@ -28,7 +28,7 @@ class GroupNorm(nn.GroupNorm):
         # function, and invoke it.
         nfeats = torch.zeros_like(feats)
         for k in range(batch_size):
-            indices = coords[:, -1] == k
+            indices = coords[:, 0] == k
             bfeats = feats[indices]
             bfeats = bfeats.transpose(0, 1).reshape(1, num_channels, -1)
             bfeats = super().forward(bfeats)


### PR DESCRIPTION
Fixed the GroupNorm module detection of batch size because the bach index is not at index 0 of the coordinate vector.