### PR TITLE
fix illegal memory access error

### DIFF
--- a/torchsparse/nn/functional/conv/kmap/build_kmap.py
+++ b/torchsparse/nn/functional/conv/kmap/build_kmap.py
@@ -190,6 +190,7 @@ def build_kernel_map(
 
     if dataflow == Dataflow.ImplicitGEMM:
         if training:
+            torch.cuda.synchronize()
             out_in_map_bwd = F.convert_transposed_out_in_map(
                 kmap["out_in_map"], make_divisible(kmap["sizes"][0], cta_M)
             )


### PR DESCRIPTION
In some cases (such as when there are a large number of points), executing convolution operations can result in illegal memory access errors. The reason is that the kernel responsible for computing the kmap has not completed execution before launching the next operation, leading to unpredictable memory access. To address this issue, an additional synchronization step is added to wait for the previous kernel to finish. This ensures that the next operation does not start until the preceding kernel has completed.