### PR TITLE
Installation from git directly. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ You may also alternatively install our library from source via:
 ```bash
 python setup.py install
 ```
+in the repository, or using  
+
+```
+pip install git+https://github.com/mit-han-lab/torchsparse.git
+```
+without the need to clone the repository. 
 
 ## Benchmarks
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,12 @@ setup(
         "typing-extensions",
         "wheel",
         "rootpath",
+        "torch",
+        "torchvision"
     ],
+    dependency_links=[
+        'https://download.pytorch.org/whl/cu118'
+    ]
     cmdclass={"build_ext": BuildExtension},
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "torchsparse.backend", sources, extra_compile_args=extra_compile_args
         )
     ],
-    url="https://github.com/ioeddk/torchsparse",
+    url="https://github.com/mit-han-lab/torchsparse",
     install_requires=[
         "numpy",
         "backports.cached_property",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             "torchsparse.backend", sources, extra_compile_args=extra_compile_args
         )
     ],
+    url="https://github.com/ioeddk/torchsparse",
     install_requires=[
         "numpy",
         "backports.cached_property",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     ],
     dependency_links=[
         'https://download.pytorch.org/whl/cu118'
-    ]
+    ],
     cmdclass={"build_ext": BuildExtension},
     zip_safe=False,
 )


### PR DESCRIPTION
Fetch the repo, build the wheel locally, and install with a single line command.  

`setup.py` and `README.md` are updated, the url and installation command in the README is updated to point to the repo under the domain `mit-han-lab`. 