### PR TITLE
Move away from deprecated methods

### DIFF
--- a/torchsparse/backend/voxelize/voxelize_cuda.cu
+++ b/torchsparse/backend/voxelize/voxelize_cuda.cu
@@ -86,10 +86,10 @@ at::Tensor voxelize_forward_cuda(const at::Tensor inputs, const at::Tensor idx,
       torch::zeros({N1, c}, at::device(idx.device()).dtype(inputs.dtype()));
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      inputs.type(), "voxelize_forward_cuda", ([&]
+      inputs.scalar_type(), "voxelize_forward_cuda", [&]
                                                { voxelize_forward_kernel<scalar_t><<<N, c>>>(
                                                      N, c, N1, inputs.data_ptr<scalar_t>(), idx.data_ptr<int>(),
-                                                     counts.data_ptr<int>(), out.data_ptr<scalar_t>()); }));
+                                                     counts.data_ptr<int>(), out.data_ptr<scalar_t>()); });
 
   return out;
 }
@@ -105,10 +105,10 @@ at::Tensor voxelize_backward_cuda(const at::Tensor top_grad,
       torch::zeros({N, c}, at::device(idx.device()).dtype(top_grad.dtype()));
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      top_grad.type(), "voxelize_backward_cuda", ([&]
+      top_grad.scalar_type(), "voxelize_backward_cuda", [&]
                                                   { voxelize_backward_kernel<scalar_t><<<N, c>>>(
                                                         N, c, N1, top_grad.data_ptr<scalar_t>(), idx.data_ptr<int>(),
-                                                        counts.data_ptr<int>(), bottom_grad.data_ptr<scalar_t>()); }));
+                                                        counts.data_ptr<int>(), bottom_grad.data_ptr<scalar_t>()); });
 
   return bottom_grad;
 }


### PR DESCRIPTION
use `at::Tensor::scalar_type()` instead of `at::Tensor::type()`