### PR TITLE
[Build] Use Ninja and bundle sparsehash submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 build/
+*.egg-info/
 *.pyc
+*.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "torchsparse/backend/third_party/sparsehash"]
+	path = torchsparse/backend/third_party/sparsehash
+	url = https://github.com/sparsehash/sparsehash.git

--- a/cython_setup.py
+++ b/cython_setup.py
@@ -80,7 +80,6 @@ setup(
         "tqdm",
         "typing-extensions",
         "wheel",
-        "rootpath",
         "attributedict",
     ],
     cmdclass={"build_ext": BuildExtension},

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ tqdm
 typing-extensions
 wheel
 attributedict
-rootpath

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,11 @@ from torch.utils.cpp_extension import (
     CppExtension,
     CUDAExtension,
 )
+from torchsparse.version import __version__
 
-# from torchsparse import __version__
+print("torchsparse version:", __version__)
 
-version_file = open("./torchsparse/version.py")
-version = version_file.read().split("'")[1]
-print("torchsparse version:", version)
+build_ext = BuildExtension.with_options(no_python_abi_suffix=True, use_ninja=True)
 
 if (torch.cuda.is_available() and CUDA_HOME is not None) or (
     os.getenv("FORCE_CUDA", "0") == "1"
@@ -47,13 +46,13 @@ if not sparseconfig_path.exists():
     run(["make", "src/sparsehash/internal/sparseconfig.h"], cwd=sparsehash_dir, check=True)
 
 extra_compile_args = {
-    "cxx": ["-g", "-O3", "-fopenmp", "-lgomp", f"-I{sparsehash_dir_inc}"],
-    "nvcc": ["-O3", "-std=c++17"],
+    "cxx": ["-O3", "-fopenmp", "-lgomp", f"-I{sparsehash_dir_inc}"],
+    "nvcc": ["-O3"],
 }
 
 setup(
     name="torchsparse",
-    version=version,
+    version=__version__,
     packages=find_packages(),
     ext_modules=[
         extension_type(
@@ -61,20 +60,18 @@ setup(
         )
     ],
     url="https://github.com/mit-han-lab/torchsparse",
+    include_package_data=True,
     install_requires=[
+        "ninja",
         "numpy",
         "backports.cached_property",
         "tqdm",
         "typing-extensions",
         "wheel",
-        "rootpath",
         "torch",
         "torchvision"
     ],
-    dependency_links=[
-        'https://download.pytorch.org/whl/cu118'
-    ],
-    cmdclass={"build_ext": BuildExtension},
+    cmdclass={"build_ext": build_ext},
     zip_safe=False,
 )
 

--- a/torchsparse/nn/functional/conv/utils/collections.py
+++ b/torchsparse/nn/functional/conv/utils/collections.py
@@ -25,8 +25,6 @@
 #       IMPORT
 # --------------------------------------
 
-import rootpath
-
 import collections
 
 from . import compat

--- a/torchsparse/nn/functional/conv/utils/compat.py
+++ b/torchsparse/nn/functional/conv/utils/compat.py
@@ -25,8 +25,6 @@
 #       DEPS
 # --------------------------------------
 
-import rootpath
-
 # @see https://github.com/benjaminp/six/blob/master/six.py
 
 import sys


### PR DESCRIPTION
Issue: Build is slow and requires system-installed sparsehash

Fix:
- Use Ninja build system for faster compilation
- Bundle sparsehash as git submodule with auto-configuration
- Remove unused `rootpath` dependency