### PR TITLE
fix(hashmap): use unsigned arithmetic in murmur3 to avoid signed-over…

### DIFF
--- a/torchsparse/backend/hashmap/hashmap_cuda.cuh
+++ b/torchsparse/backend/hashmap/hashmap_cuda.cuh
@@ -52,14 +52,18 @@ __device__ int hash(key_type key, int _capacity){
 
 template <typename key_type>
 __device__ int hash_murmur3(key_type key, int _capacity){
-  // use the murmur3 hash function for int32
-  int64_t k = (int64_t)key;
+  // Murmur3 finalizer using unsigned arithmetic to avoid signed-overflow UB.
+  // The multiplies overflow int64; signed overflow is UB in CUDA and NVCC may
+  // optimize away a post-hoc negativity check, leaving `k % _capacity` negative
+  // -> negative table index -> illegal memory access. Unsigned wraps defined.
+  uint64_t k = (uint64_t)(int64_t)key;
   k ^= k >> 16;
-  k *= 0x85ebca6b;
+  k *= UINT64_C(0x85ebca6b);
   k ^= k >> 13;
-  k *= 0xc2b2ae35;
+  k *= UINT64_C(0xc2b2ae35);
   k ^= k >> 16;
-  return k % _capacity;
+  // unsigned modulo is always in [0, _capacity) -- no negative index possible
+  return (int)(k % (uint64_t)_capacity);
 }
 
 template <typename key_type, typename val_type>


### PR DESCRIPTION
…flow UB

The murmur3 finalizer computed the hash in int64_t. The two multiplies overflow, and signed integer overflow is undefined behavior in CUDA: NVCC may assume it cannot happen and optimize away any later negativity handling, leaving `k % _capacity` negative. A negative slot index is then used to address the hash table -> illegal memory access ("CUDA error: an illegal memory access was encountered"), observed on large-scale / large-coordinate point clouds.

Compute the finalizer in uint64_t (defined wraparound) and take an unsigned modulo, which is always in [0, _capacity). Hash values are unchanged for inputs that did not overflow into the sign bit; only the UB and negative indices are removed.